### PR TITLE
version updates keep breaking docs test

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# BitcoinSource v0.0.1-dev
+# BitcoinSource vv0.1.12
 
 ## Bitcoin Cash
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# BitcoinSource vv0.1.12
+# BitcoinSource v0.1.12
 
 ## Bitcoin Cash
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinsource",
-  "version": "v0.1.12",
+  "version": "0.1.12",
   "description": "A simple, safe, and powerful JavaScript Bitcoin Cash library.",
   "author": "Clemens Ley <ley.clemens@gmail.com>",
   "main": "src/bitcoinsource.js",


### PR DESCRIPTION
(1) according to semantic versioning guidelines the version should be entered in package.json without the 'v'
(2) do we need the documentation test? it keep breaking. Either need a build step to automate updating index.md or disable the test