### PR TITLE
Interpreter set altstack fix typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# BitcoinSource v0.0.1-dev
+# BitcoinSource vv0.1.12
 
 ## Bitcoin Cash
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinsource",
-  "version": "v0.1.12",
+  "version": "0.1.12",
   "description": "A simple, safe, and powerful JavaScript Bitcoin Cash library.",
   "author": "Clemens Ley <ley.clemens@gmail.com>",
   "main": "src/bitcoinsource.js",

--- a/src/script/interpreter.js
+++ b/src/script/interpreter.js
@@ -166,7 +166,7 @@ Interpreter.prototype.set = function (obj) {
   this.tx = obj.tx || this.tx;
   this.nin = typeof obj.nin !== 'undefined' ? obj.nin : this.nin;
   this.stack = obj.stack || this.stack;
-  this.altstack = obj.altack || this.altstack;
+  this.altstack = obj.altstack || this.altstack;
   this.pc = typeof obj.pc !== 'undefined' ? obj.pc : this.pc;
   this.pbegincodehash = typeof obj.pbegincodehash !== 'undefined' ? obj.pbegincodehash : this.pbegincodehash;
   this.nOpCount = typeof obj.nOpCount !== 'undefined' ? obj.nOpCount : this.nOpCount;

--- a/test/script/interpreter.js
+++ b/test/script/interpreter.js
@@ -150,8 +150,43 @@ describe('Interpreter', function() {
       var verified = Interpreter().verify(scriptSig, scriptPubkey, tx, inputIndex, flags);
       verified.should.equal(true);
     });
-  });
 
+    it('should set values on interpreter', function() {
+      const script = Script('OP_1')
+      const tx = new Transaction()
+      const stack = []
+      stack.push(Interpreter.true)
+      const altstack = []
+      altstack.push(Interpreter.false)
+      const vfExec = []
+      vfExec.push(true)
+      const interp = Interpreter({
+        script: script,
+        tx: tx,
+        nin: 9,
+        stack: stack,
+        altstack: altstack,
+        pc: 99,
+        pbegincodehash: 88,
+        nOpCount: 77,
+        vfExec: vfExec,
+        errstr: 'testing',
+        flags: Interpreter.SCRIPT_VERIFY_STRICTENC
+      });
+      interp.script.should.equal(script)
+      interp.tx.should.equal(tx)
+      interp.nin.should.equal(9)
+      interp.stack.should.equal(stack);
+      interp.altstack.should.equal(altstack);
+      interp.pc.should.equal(99);
+      interp.pbegincodehash.should.equal(88);
+      interp.nOpCount.should.equal(77);
+      interp.vfExec[0].should.equal(true);
+      interp.errstr.should.equal('testing');
+      interp.flags.should.equal(Interpreter.SCRIPT_VERIFY_STRICTENC);
+    });
+
+  });
 
   var getFlags = function getFlags(flagstr) {
     var flags = 0;


### PR DESCRIPTION
If you notice interpreter.cpp has a typo when setting the altstack.
All forks of bitcore have this typo.
This pull requests fixes the typo and adds tests for all interpreter.set values.