### PR TITLE
OutputId

### DIFF
--- a/src/transaction/index.js
+++ b/src/transaction/index.js
@@ -2,6 +2,7 @@ module.exports = require('./transaction');
 
 module.exports.Input = require('./input');
 module.exports.Output = require('./output');
+module.exports.OutputId = require('./output-id');
 module.exports.UnspentOutput = require('./unspentoutput');
 module.exports.Signature = require('./signature');
 module.exports.Sighash = require('./sighash');

--- a/src/transaction/output-id.js
+++ b/src/transaction/output-id.js
@@ -6,8 +6,8 @@ const TXID_REGEX = /[0-9A-Fa-f]{64}/
 class OutputId {
     /**
       Creates an output id from a transaction id and output index
-     * @param {string} txid Transaction id in hex format
-     * @param {number} vout Output index
+     * @param {string} txId Transaction id in hex format
+     * @param {number} outputIndex Output index
      */
     constructor(txId, outputIndex) {
         if (!TXID_REGEX.test(txId))

--- a/src/transaction/output-id.js
+++ b/src/transaction/output-id.js
@@ -1,0 +1,64 @@
+const TXID_REGEX = /[0-9A-Fa-f]{64}/
+
+/**
+ * Output identifier for a Bitcoin transaction
+ */
+class OutputId {
+    /**
+      Creates an output id from a transaction id and output index
+     * @param {string} txid Transaction id in hex format
+     * @param {number} vout Output index
+     */
+    constructor(txId, outputIndex) {
+        if (!TXID_REGEX.test(txId))
+            throw new Error(`txId not in a valid hex format: ${txId}`)
+
+        if (outputIndex < 0 || outputIndex > 4294967295 || Number.isNaN(outputIndex))
+            throw new Error(`outputIndex out of range: ${outputIndex}`)
+
+        this.txId = txId
+        this.outputIndex = outputIndex
+    }
+
+    /**
+     * Serializes the output id into a compressed string form
+     */
+    toString() {
+        return `${this.txId}:${this.outputIndex}`
+    }
+
+    /**
+     * Parses the output id form its compressed string form
+     * @param {string} s String to parse
+     */
+    static fromString(s) {
+        const parts = s.split(':')
+
+        if (parts.length !== 2)
+            throw new Error("Invalid string format")
+
+        return new OutputId(parts[0], parseInt(parts[1], 10))
+    }
+
+    /**
+     * Get the transaction id in hex format
+     */
+    get txid() { return this.txId }
+
+    /**
+     * Get the output index
+     */
+    get vout() { return this.outputIndex }
+
+    /**
+     * Returns whether two OutputIds refer to the same output
+     * @param {OutputId} other Other object to compare
+     * @returns {bool} True if the objects refer to the same output, false if not
+     */
+    equals(other) {
+        return this.outputIndex === other.outputIndex &&
+            this.txId.toLowerCase() === other.txId.toLowerCase()
+    }
+}
+
+module.exports = OutputId

--- a/test/transaction/output-id.js
+++ b/test/transaction/output-id.js
@@ -1,0 +1,88 @@
+var bch = require('../..');
+var expect = require('chai').expect;
+var OutputId = bch.Transaction.OutputId;
+
+const DUMMY_TXID = "b18d0e8bd48c62124f5db85e2d5b3d288e23f72937f513bb009299607f253089"
+
+describe('OutputId', () => {
+    describe('new', () => {
+        it('should create a new object from txid and string', () => {
+            const outputId = new OutputId(DUMMY_TXID, 4)
+            expect(outputId.txId).to.equal(DUMMY_TXID)
+            expect(outputId.outputIndex).to.equal(4)
+        })
+
+        it('should fail if txid is not properly formatted', () => {
+            expect(() => new OutputId('', 0)).to.throw()
+            expect(() => new OutputId('1Nh7uHdvY6fNwtQtM1G5EZAFPLC33B59rB', 0)).to.throw()
+            expect(() => new OutputId('abcdef0123456789', 0)).to.throw()
+        })
+
+        it('should fail if output index is outside range', () => {
+            expect(() => new OutputId(DUMMY_TXID, -1)).to.throw()
+            expect(() => new OutputId(DUMMY_TXID, 5000000000)).to.throw()
+        })
+    })
+
+    describe('toString', () => {
+        it('should serialize to colon format', () => {
+            const outputId = new OutputId(DUMMY_TXID, 4)
+            expect(outputId.toString()).to.equal(DUMMY_TXID + ":4")
+        })
+    })
+
+    describe('fromString', () => {
+        it('should parse colon format', () => {
+            const outputId = OutputId.fromString(DUMMY_TXID + ":4")
+            expect(outputId.txId).to.equal(DUMMY_TXID)
+            expect(outputId.outputIndex).to.equal(4)
+        })
+
+        it('should fail to parse incorrect formats', () => {
+            expect(() => OutputId.fromString('')).to.throw()
+            expect(() => OutputId.fromString(':')).to.throw()
+            expect(() => OutputId.fromString(DUMMY_TXID)).to.throw()
+            expect(() => OutputId.fromString(":4")).to.throw()
+            expect(() => OutputId.fromString(DUMMY_TXID + ":")).to.throw()
+            expect(() => OutputId.fromString(DUMMY_TXID + ":4:0")).to.throw()
+        })
+    })
+
+    describe('get', () => {
+        it('txid should return the same as txId', () => {
+            const outputId = new OutputId(DUMMY_TXID, 4)
+            expect(outputId.txid).to.equal(DUMMY_TXID)
+        })
+
+        it('vout should return the same as outputIndex', () => {
+            const outputId = new OutputId(DUMMY_TXID, 4)
+            expect(outputId.vout).to.equal(4)
+        })
+    })
+
+    describe('equals', () => {
+        it('should be equal when txid and output id are same', () => {
+            const outputId1 = new OutputId(DUMMY_TXID, 1)
+            const outputId2 = new OutputId(DUMMY_TXID, 1)
+            expect(outputId1.equals(outputId2)).to.equal(true)
+        })
+
+        it('should not be equal when txids are different', () => {
+            const outputId1 = new OutputId(DUMMY_TXID, 1)
+            const outputId2 = new OutputId(DUMMY_TXID.replace('0', '1'), 1)
+            expect(outputId1.equals(outputId2)).to.equal(false)
+        })
+
+        it('should not be equal when output indexes are different', () => {
+            const outputId1 = new OutputId(DUMMY_TXID, 1)
+            const outputId2 = new OutputId(DUMMY_TXID, 2)
+            expect(outputId1.equals(outputId2)).to.equal(false)
+        })
+
+        it('should be equal for all txId capitalizations', () => {
+            const outputId1 = new OutputId(DUMMY_TXID.toLowerCase(), 3)
+            const outputId2 = new OutputId(DUMMY_TXID.toUpperCase(), 3)
+            expect(outputId1.equals(outputId2)).to.equal(true)
+        })
+    })
+})


### PR DESCRIPTION
Creates a common OutputId object to use across projects.

I stripped out the flow types for now, but will put back once flow is hooked up.

Test Plan:
- [x] Added unit tests
- [x] lint