### PR TITLE
Add dist to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ bower_components
 report
 .DS_Store
 
+dist
 .build/
 .nyc_output/
 


### PR DESCRIPTION
The build scripts create a dist folder but it isn't in .gitignore