### PR TITLE
Update big-integer library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinsource",
-  "version": "0.0.1-dev",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -510,9 +510,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.36",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
+      "version": "1.6.42",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.42.tgz",
+      "integrity": "sha512-3UQFKcRMx+5Z+IK5vYTMYK2jzLRJkt+XqyDdacgWgtMjjuifKpKTFneJLEgeBElOE2/lXZ1LcMcb5s8pwG2U8Q=="
     },
     "binary-extensions": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "request": "browser-request"
   },
   "dependencies": {
-    "big-integer": "^1.6.36",
+    "big-integer": "^1.6.42",
     "bn.js": "=2.0.4",
     "bs58": "=2.0.0",
     "buffer-compare": "=1.0.0",


### PR DESCRIPTION
The big-integer library pushed out an update recently to remove uses of 'eval' in their code.

https://github.com/peterolson/BigInteger.js/commit/b2640ad2f7163aba4e95742dec56d62ff6147f85#diff-82f314e495f1c3ec2a3bc0602627d16a

This will fix rollup errors in all of our projects.

**Test Plan**
- [x] Built bitcoin-source-api with this new version of bitcoin-source and saw no errors