### PR TITLE
Use Imports in Tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,12 +103,12 @@ This helps to make tests more useful as examples, and more independent of where 
 
 DO:
 ```javascript
-var bitcoinsource = require('../');
-var PublicKey = bitcoinsource.PublicKey;
+import Bitcoin from '../'
+const { PublicKey } = Bitcoin
 ```
 DON'T:
 ```javascript
-var PublicKey = require('../src/publickey');
+import PublicKey from '../src/publickey'
 ```
 
 #### Data for Tests Included in a JSON File

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,7 @@
 
 ## Generate a random address
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const privateKey = new Bitcoin.PrivateKey();
 const address = privateKey.toAddress();
@@ -12,7 +12,7 @@ console.log(address.toString()) // 15WZwpw3BofscM2u43ji85BXucai5YGToL
 
 ## Generate a address from a SHA256 hash
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const value = Buffer.from('Bitcoin Cash - Peer-to-Peer Electronic Cash');
 const hash = Bitcoin.crypto.Hash.sha256(value);
@@ -24,7 +24,7 @@ console.log(address.toString()) // 126tFHmNHNAXDYT1QeEBEwBbEojib1VZyg
 
 ## Translate an address to any Bitcoin Cash address format
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const Address = Bitcoin.Address;
 const BitpayFormat = Address.BitpayFormat;
@@ -39,7 +39,7 @@ console.log(address.toString(CashAddrFormat)) // bitcoincash:qr0q67nsn66cf3klfuf
 
 ## Read an address from any Bitcoin Cash address format
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const Address = Bitcoin.Address;
 const fromString = Address.fromString;
@@ -56,7 +56,7 @@ const cashaddr = fromString('bitcoincash:qr0q67nsn66cf3klfufttr0vuswh3w5nt5jqpp2
 
 ## Import an address via WIF
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const wif = 'Kxr9tQED9H44gCmp6HAdmemAzU3n84H3dGkuWTKvE23JgHMW8gct';
 const address = new Bitcoin.PrivateKey(wif).toAddress();
@@ -66,7 +66,7 @@ console.log(address.toString()) // 19AAjaTUbRjQCMuVczepkoPswiZRhjtg31
 
 ## Create a Transaction
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const privateKey = new Bitcoin.PrivateKey('L1uyy5qTuGrVXrmrsvHWHgVzW9kKdrp27wBC7Vs6nZDTF2BRUVwy');
 const utxo = {
@@ -86,7 +86,7 @@ console.log(transaction.toString()) // 01000000018689302ea03ef...
 
 ## Verify a Bitcoin message
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const Message = Bitcoin.Message;
 
@@ -99,7 +99,7 @@ console.log(message.verify(address, signature)) // true
 
 ## Sign a Bitcoin message
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const Message = Bitcoin.Message;
 
@@ -113,7 +113,7 @@ console.log(signature.toString()) // IJuZCwN/4HtIRulOb/zRLU1oCP...
 
 ## Create an OP RETURN transaction
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const privateKey = new Bitcoin.PrivateKey('L1uyy5qTuGrVXrmrsvHWHgVzW9kKdrp27wBC7Vs6nZDTF2BRUVwy');
 const utxo = {
@@ -133,7 +133,7 @@ console.log(transaction.toString()) // 01000000018689302ea03ef...
 
 ## Create a 2-of-3 multisig P2SH address
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const publicKeys = [
   '026477115981fe981a6918a6297d9803c4dc04f328f22041bedff886bbc2962e01',
@@ -148,7 +148,7 @@ console.log(address.toString()) // 36NUkt6FWUi3LAWBqWRdDmdTWbt91Yvfu7
 
 ## Spend from a 2-of-2 multisig P2SH address
 ```javascript
-const Bitcoin = require('bitcoinsource');
+import Bitcoin from 'bitcoinsource'
 
 const privateKeys = [
   new Bitcoin.PrivateKey('91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx'),

--- a/docs/hierarchical.md
+++ b/docs/hierarchical.md
@@ -10,7 +10,7 @@ An instance of a [PrivateKey](privatekey.md) that also contains information requ
 Sample usage:
 
 ```javascript
-var bitcore = require('bitcore');
+import bitcore from 'bitcore'
 var HDPrivateKey = bitcore.HDPrivateKey;
 
 var hdPrivateKey = new HDPrivateKey();

--- a/docs/publickey.md
+++ b/docs/publickey.md
@@ -32,7 +32,7 @@ It's important to note that there are two possible ways to represent a public ke
 Example:
 
 ```javascript
-> var bitcore = require('bitcore');
+> import bitcore from 'bitcore'
 
 // compressed public key starting with 0x03 (greater than midpoint of curve)
 > var compressedPK = bitcore.PublicKey('030589ee559348bd6a7325994f9c8eff12bd'+

--- a/docs/unit.md
+++ b/docs/unit.md
@@ -6,7 +6,7 @@ To understand the need of using the `Unit` class when dealing with unit conversi
 ```
 > 81.99 * 100000 // wrong
 8198999.999999999
-> var bitcore = require('bitcore');
+> import bitcore from 'bitcore'
 > var Unit = bitcore.Unit;
 > Unit.fromMilis(81.99).toSatoshis() // correct
 8199000

--- a/oddities.md
+++ b/oddities.md
@@ -10,8 +10,8 @@ function sighash(transaction, sighashType, inputNumber, subscript, satoshisBN) {
   // TODO If this is moved in the global scope a bunch of tests fails. This is probably
   // due to a circular dependency. This file could probably use a major overhaul.
   // See GitHub isuse #42.
-  const Transaction = require('./transaction');
-  const Input = require('./input');
+  import Transaction from './transaction'
+  import Input from './input/input'
 ```
 
 

--- a/test/address.js
+++ b/test/address.js
@@ -1,17 +1,15 @@
+import chai from 'chai'
 import Bitcoin from './bitcoin'
 
-const chai = require('chai')
+import validbase58 from './data/bitcoind/base58_keys_valid.json'
+import invalidbase58 from './data/bitcoind/base58_keys_invalid.json'
 
 const should = chai.should()
 const { expect } = chai
-
 const { PublicKey } = Bitcoin
 const { Address } = Bitcoin
 const { Script } = Bitcoin
 const { Networks } = Bitcoin
-
-const validbase58 = require('./data/bitcoind/base58_keys_valid.json')
-const invalidbase58 = require('./data/bitcoind/base58_keys_invalid.json')
 
 // livenet valid
 const PKHLivenet = [

--- a/test/block/block.js
+++ b/test/block/block.js
@@ -1,22 +1,21 @@
+import chai from 'chai'
+import fs from 'fs'
 import Bitcoin from '../bitcoin'
+import data from '../data/blk86756-testnet'
+import dataBlocks from '../data/bitcoind/blocks'
 
+const should = chai.should()
 const { BN } = Bitcoin.crypto
 const { BufferReader } = Bitcoin.encoding
 const { BufferWriter } = Bitcoin.encoding
 const { BlockHeader } = Bitcoin
 const { Block } = Bitcoin
-const chai = require('chai')
-const fs = require('fs')
-
-const should = chai.should()
 const { Transaction } = Bitcoin
 
 // https://test-insight.bitpay.com/block/000000000b99b16390660d79fcc138d2ad0c89a0d044c4201a02bdf1f61ffa11
 const dataRawBlockBuffer = fs.readFileSync('test/data/blk86756-testnet.dat')
 const dataRawBlockBinary = fs.readFileSync('test/data/blk86756-testnet.dat', 'binary')
 const dataJson = fs.readFileSync('test/data/blk86756-testnet.json').toString()
-const data = require('../data/blk86756-testnet')
-const dataBlocks = require('../data/bitcoind/blocks')
 
 describe('Block', function() {
   const { blockhex } = data

--- a/test/block/blockheader.js
+++ b/test/block/blockheader.js
@@ -1,20 +1,20 @@
 /* eslint-disable no-new */
 
+import chai from 'chai'
+import fs from 'fs'
 import Bitcoin from '../bitcoin'
+import data from '../data/blk86756-testnet'
 
+const should = chai.should()
 const { BN } = Bitcoin.crypto
 const { BufferReader } = Bitcoin.encoding
 const { BufferWriter } = Bitcoin.encoding
-
 const { BlockHeader } = Bitcoin
-const fs = require('fs')
-const should = require('chai').should()
 
 // https://test-insight.bitpaycrypto.com/block/000000000b99b16390660d79fcc138d2ad0c89a0d044c4201a02bdf1f61ffa11
 const dataRawBlockBuffer = fs.readFileSync('test/data/blk86756-testnet.dat')
 const dataRawBlockBinary = fs.readFileSync('test/data/blk86756-testnet.dat', 'binary')
 const dataRawId = '000000000b99b16390660d79fcc138d2ad0c89a0d044c4201a02bdf1f61ffa11'
-const data = require('../data/blk86756-testnet')
 
 describe('BlockHeader', function() {
   const { version } = data

--- a/test/block/merkleblock.js
+++ b/test/block/merkleblock.js
@@ -1,13 +1,13 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
+import data from '../data/merkleblocks'
+import transactionVector from '../data/tx_creation'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { MerkleBlock } = Bitcoin
 const { BufferReader } = Bitcoin.encoding
 const { BufferWriter } = Bitcoin.encoding
 const { Transaction } = Bitcoin
-const data = require('../data/merkleblocks.js')
-const transactionVector = require('../data/tx_creation')
 
 describe('MerkleBlock', function() {
   const blockhex = data.HEX[0]

--- a/test/crypto/bn.js
+++ b/test/crypto/bn.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { BN } = Bitcoin.crypto
 
 describe('BN', function() {

--- a/test/crypto/ecdsa.js
+++ b/test/crypto/ecdsa.js
@@ -1,5 +1,8 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
+import vectors from '../data/ecdsa'
 
+const should = chai.should()
 const { ECDSA } = Bitcoin.crypto
 const { Hash } = Bitcoin.crypto
 const Privkey = Bitcoin.PrivateKey
@@ -7,8 +10,6 @@ const Pubkey = Bitcoin.PublicKey
 const { Signature } = Bitcoin.crypto
 const { BN } = Bitcoin.crypto
 const point = Bitcoin.crypto.Point
-const should = require('chai').should()
-const vectors = require('../data/ecdsa')
 
 describe('ECDSA', function() {
   it('instantiation', function() {

--- a/test/crypto/hash.js
+++ b/test/crypto/hash.js
@@ -1,8 +1,8 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-require('chai').should()
-
 const { Hash } = Bitcoin.crypto
+chai.should()
 
 describe('Hash', function() {
   const buf = Buffer.from([0, 1, 2, 3, 253, 254, 255])

--- a/test/crypto/point.js
+++ b/test/crypto/point.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { Point } = Bitcoin.crypto
 const { BN } = Bitcoin.crypto
 

--- a/test/crypto/signature.js
+++ b/test/crypto/signature.js
@@ -1,15 +1,14 @@
+import _ from 'lodash'
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
+import sigCanonical from '../data/bitcoind/sig_canonical'
+import sigNonCanonical from '../data/bitcoind/sig_noncanonical'
 
-const _ = require('lodash')
-const should = require('chai').should()
-
+const should = chai.should()
 const { BN } = Bitcoin.crypto
 const { Signature } = Bitcoin.crypto
 const JSUtil = Bitcoin.util.js
 const { Interpreter } = Bitcoin.Script
-
-const sigCanonical = require('../data/bitcoind/sig_canonical')
-const sigNonCanonical = require('../data/bitcoind/sig_noncanonical')
 
 describe('Signature', function() {
   it('should make a blank signature', function() {

--- a/test/docs.js
+++ b/test/docs.js
@@ -1,6 +1,5 @@
+import fs from 'fs'
 import Bitcoin from './bitcoin'
-
-const fs = require('fs')
 
 describe('Documentation', function() {
   it('major and minor versions should match', function() {

--- a/test/encoding/base58.js
+++ b/test/encoding/base58.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { Base58 } = Bitcoin.encoding
 
 describe('Base58', function() {

--- a/test/encoding/base58check.js
+++ b/test/encoding/base58check.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { Base58Check } = Bitcoin.encoding
 const { Base58 } = Bitcoin.encoding
 

--- a/test/encoding/bufferreader.js
+++ b/test/encoding/bufferreader.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { BufferWriter } = Bitcoin.encoding
 const { BufferReader } = Bitcoin.encoding
 const { BN } = Bitcoin.crypto

--- a/test/encoding/bufferwriter.js
+++ b/test/encoding/bufferwriter.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { BufferWriter } = Bitcoin.encoding
 const { BufferReader } = Bitcoin.encoding
 const { BN } = Bitcoin.crypto

--- a/test/encoding/varint.js
+++ b/test/encoding/varint.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { BN } = Bitcoin.crypto
 const { BufferReader } = Bitcoin.encoding
 const { BufferWriter } = Bitcoin.encoding

--- a/test/hdkeys.js
+++ b/test/hdkeys.js
@@ -1,16 +1,15 @@
 /* eslint-disable camelcase */
 
+import _ from 'lodash'
+import chai from 'chai'
+import sinon from 'sinon'
 import Bitcoin from './bitcoin'
 
-const _ = require('lodash')
-// eslint-disable-next-line no-unused-vars
-const should = require('chai').should()
-const { expect } = require('chai')
-const sinon = require('sinon')
-
+const { expect } = chai
 const { Networks } = Bitcoin
 const { HDPrivateKey } = Bitcoin
 const { HDPublicKey } = Bitcoin
+chai.should()
 
 // test vectors: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 const vector1_master = '000102030405060708090a0b0c0d0e0f'

--- a/test/hdprivatekey.js
+++ b/test/hdprivatekey.js
@@ -1,13 +1,12 @@
+import _ from 'lodash'
+import assert from 'assert'
+import chai from 'chai'
 import Bitcoin from './bitcoin'
 
-const _ = require('lodash')
-const assert = require('assert')
-const should = require('chai').should()
-const { expect } = require('chai')
-
+const should = chai.should()
+const { expect } = chai
 const { errors } = Bitcoin
 const hdErrors = errors.HDPrivateKey
-
 const { Networks } = Bitcoin
 const BufferUtil = Bitcoin.util.buffer
 const { HDPrivateKey } = Bitcoin

--- a/test/hdpublickey.js
+++ b/test/hdpublickey.js
@@ -1,9 +1,9 @@
+import _ from 'lodash'
+import assert from 'assert'
+import chai from 'chai'
 import Bitcoin from './bitcoin'
 
-const _ = require('lodash')
-const assert = require('assert')
-const { expect } = require('chai')
-
+const { expect } = chai
 const { errors } = Bitcoin
 const hdErrors = Bitcoin.errors.HDPublicKey
 const BufferUtil = Bitcoin.util.buffer

--- a/test/message.js
+++ b/test/message.js
@@ -1,10 +1,8 @@
+import chai from 'chai'
 import Bitcoin from './bitcoin'
-
-const chai = require('chai')
 
 const { expect } = chai
 const should = chai.should()
-
 const { Address } = Bitcoin
 const { Signature } = Bitcoin.crypto
 const { Message } = Bitcoin

--- a/test/mnemonic/mnemonic.js
+++ b/test/mnemonic/mnemonic.js
@@ -1,11 +1,10 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
-
-const chai = require('chai')
+import bip39Vectors from '../data/mnemonics.json'
 
 const should = chai.should()
 const { Mnemonic } = Bitcoin
 const { errors } = Bitcoin
-const bip39Vectors = require('../data/mnemonics.json')
 
 describe('Mnemonic', function() {
   this.timeout(30000)

--- a/test/networks.js
+++ b/test/networks.js
@@ -1,8 +1,8 @@
+import chai from 'chai'
 import Bitcoin from './bitcoin'
 
-const { expect } = require('chai')
-const should = require('chai').should()
-
+const { expect } = chai
+const should = chai.should()
 const networks = Bitcoin.Networks
 
 describe('Networks', function() {

--- a/test/opcode.js
+++ b/test/opcode.js
@@ -1,7 +1,6 @@
+import _ from 'lodash'
+import chai from 'chai'
 import Bitcoin from './bitcoin'
-
-const _ = require('lodash')
-const chai = require('chai')
 
 const should = chai.should()
 const { expect } = chai

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -1,18 +1,15 @@
+import chai from 'chai'
 import Bitcoin from './bitcoin'
-
-const chai = require('chai')
+import validbase58 from './data/bitcoind/base58_keys_valid.json'
+import invalidbase58 from './data/bitcoind/base58_keys_invalid.json'
 
 const should = chai.should()
 const { expect } = chai
-
 const { BN } = Bitcoin.crypto
 const { Point } = Bitcoin.crypto
 const { PrivateKey } = Bitcoin
 const { Networks } = Bitcoin
 const { Base58Check } = Bitcoin.encoding
-
-const validbase58 = require('./data/bitcoind/base58_keys_valid.json')
-const invalidbase58 = require('./data/bitcoind/base58_keys_invalid.json')
 
 describe('PrivateKey', function() {
   const hex = '96c132224121b509b7d0a16245e957d9192609c5637c6228311287b1be21627a'

--- a/test/publickey.js
+++ b/test/publickey.js
@@ -1,8 +1,8 @@
+import chai from 'chai'
 import Bitcoin from './bitcoin'
 
-const should = require('chai').should()
-const { expect } = require('chai')
-
+const should = chai.should()
+const { expect } = chai
 const { Point } = Bitcoin.crypto
 const { BN } = Bitcoin.crypto
 const { PublicKey } = Bitcoin

--- a/test/script/interpreter.js
+++ b/test/script/interpreter.js
@@ -1,7 +1,11 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
+import scriptValid from '../data/bitcoind/script_valid'
+import scriptInvalid from '../data/bitcoind/script_invalid'
+import txValid from '../data/bitcoind/tx_valid'
+import txInvalid from '../data/bitcoind/tx_invalid'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { Interpreter } = Bitcoin.Script
 const { Transaction } = Bitcoin
 const { PrivateKey } = Bitcoin
@@ -9,11 +13,6 @@ const { Script } = Bitcoin
 const { BN } = Bitcoin.crypto
 const { BufferWriter } = Bitcoin.encoding
 const { Opcode } = Bitcoin
-
-const scriptValid = require('../data/bitcoind/script_valid')
-const scriptInvalid = require('../data/bitcoind/script_invalid')
-const txValid = require('../data/bitcoind/tx_valid')
-const txInvalid = require('../data/bitcoind/tx_invalid')
 
 // the script string format used in bitcoind data tests
 Script.fromBitcoindString = function(str) {

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -1,8 +1,8 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-const { expect } = require('chai')
-
+const should = chai.should()
+const { expect } = chai
 const BufferUtil = Bitcoin.util.buffer
 const { Script } = Bitcoin
 const { Networks } = Bitcoin

--- a/test/transaction/deserialize.js
+++ b/test/transaction/deserialize.js
@@ -1,9 +1,8 @@
 import Bitcoin from '../bitcoin'
+import vectorsValid from '../data/bitcoind/tx_valid.json'
+import vectorsInvalid from '../data/bitcoind/tx_invalid.json'
 
 const { Transaction } = Bitcoin
-
-const vectorsValid = require('../data/bitcoind/tx_valid.json')
-const vectorsInvalid = require('../data/bitcoind/tx_invalid.json')
 
 describe('Transaction deserialization', function() {
   describe('valid transaction test case', function() {

--- a/test/transaction/input/input.js
+++ b/test/transaction/input/input.js
@@ -1,9 +1,9 @@
+import _ from 'lodash'
+import chai from 'chai'
 import Bitcoin from '../../bitcoin'
 
-const should = require('chai').should()
-const { expect } = require('chai')
-const _ = require('lodash')
-
+const should = chai.should()
+const { expect } = chai
 const { errors } = Bitcoin
 const { PrivateKey } = Bitcoin
 const { Address } = Bitcoin

--- a/test/transaction/input/multisig.js
+++ b/test/transaction/input/multisig.js
@@ -1,16 +1,16 @@
 /* eslint-disable no-unused-expressions */
 
-import bch from '../../..'
+import _ from 'lodash'
+import chai from 'chai'
+import Bitcoin from '../../bitcoin'
 
-const should = require('chai').should()
-const _ = require('lodash')
-
-const { Transaction } = bch
-const { PrivateKey } = bch
-const { Address } = bch
-const { Script } = bch
-const { Signature } = bch.crypto
-const MultiSigInput = bch.Transaction.Input.MultiSig
+const should = chai.should()
+const { Transaction } = Bitcoin
+const { PrivateKey } = Bitcoin
+const { Address } = Bitcoin
+const { Script } = Bitcoin
+const { Signature } = Bitcoin.crypto
+const MultiSigInput = Bitcoin.Transaction.Input.MultiSig
 
 describe('MultiSigInput', function() {
   const privateKey1 = new PrivateKey('KwF9LjRraetZuEjR8VqEq539z137LW5anYDUnVK11vM3mNMHTWb4')

--- a/test/transaction/input/multisigscripthash.js
+++ b/test/transaction/input/multisigscripthash.js
@@ -1,6 +1,5 @@
+import _ from 'lodash'
 import Bitcoin from '../../bitcoin'
-
-const _ = require('lodash')
 
 const { Transaction } = Bitcoin
 const { PrivateKey } = Bitcoin

--- a/test/transaction/output-id.js
+++ b/test/transaction/output-id.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const { expect } = require('chai')
-
+const { expect } = chai
 const { OutputId } = Bitcoin.Transaction
 
 const DUMMY_TXID = 'b18d0e8bd48c62124f5db85e2d5b3d288e23f72937f513bb009299607f253089'

--- a/test/transaction/output.js
+++ b/test/transaction/output.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-new */
 
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { BN } = Bitcoin.crypto
 const { BufferWriter } = Bitcoin.encoding
 const { BufferReader } = Bitcoin.encoding

--- a/test/transaction/sighash.js
+++ b/test/transaction/sighash.js
@@ -1,11 +1,10 @@
 import Bitcoin from '../bitcoin'
+import vectorsSighash from '../data/sighash.json'
 
 const { Script } = Bitcoin
 const { BN } = Bitcoin.crypto
 const { Transaction } = Bitcoin
 const sighash = Transaction.Sighash
-
-const vectorsSighash = require('../data/sighash.json')
 
 describe('sighash', function() {
   it('Should require amount for sigHash ForkId=0', function() {

--- a/test/transaction/signature.js
+++ b/test/transaction/signature.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const { expect } = require('chai')
-
+const { expect } = chai
 const { Transaction } = Bitcoin
 const TransactionSignature = Bitcoin.Transaction.Signature
 const { Script } = Bitcoin

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -1,13 +1,14 @@
 /* eslint-disable no-unused-expressions, no-new, camelcase */
 
+import _ from 'lodash'
+import chai from 'chai'
+import sinon from 'sinon'
 import Bitcoin from '../bitcoin'
+import fixture from '../data/bip69.json'
+import transactionVector from '../data/tx_creation'
 
-const should = require('chai').should()
-const { expect } = require('chai')
-const _ = require('lodash')
-const sinon = require('sinon')
-const fixture = require('../data/bip69.json')
-
+const should = chai.should()
+const { expect } = chai
 const { BN } = Bitcoin.crypto
 const { Transaction } = Bitcoin
 const { Input } = Bitcoin.Transaction
@@ -17,8 +18,6 @@ const { Script } = Bitcoin
 const { Address } = Bitcoin
 const { Opcode } = Bitcoin
 const { errors } = Bitcoin
-
-const transactionVector = require('../data/tx_creation')
 
 const tx_empty_hex = '01000000000000000000'
 

--- a/test/transaction/unspentoutput.js
+++ b/test/transaction/unspentoutput.js
@@ -1,7 +1,6 @@
+import _ from 'lodash'
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
-
-const _ = require('lodash')
-const chai = require('chai')
 
 const { expect } = chai
 const { UnspentOutput } = Bitcoin.Transaction

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,8 +1,8 @@
+import chai from 'chai'
 import Bitcoin from './bitcoin'
 
-const should = require('chai').should()
-const { expect } = require('chai')
-
+const should = chai.should()
+const { expect } = chai
 const { errors } = Bitcoin
 const { Unit } = Bitcoin
 

--- a/test/uri.js
+++ b/test/uri.js
@@ -1,6 +1,5 @@
+import chai from 'chai'
 import Bitcoin from './bitcoin'
-
-const chai = require('chai')
 
 const { expect } = chai
 const { Networks } = Bitcoin

--- a/test/util/buffer.js
+++ b/test/util/buffer.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const { expect } = require('chai')
-
+const { expect } = chai
 const { errors } = Bitcoin
 const BufferUtil = Bitcoin.util.buffer
 

--- a/test/util/preconditions.js
+++ b/test/util/preconditions.js
@@ -1,7 +1,7 @@
+import chai from 'chai'
 import Bitcoin from '../bitcoin'
 
-const should = require('chai').should()
-
+const should = chai.should()
 const { errors } = Bitcoin
 const $ = Bitcoin.util.preconditions
 const { PrivateKey } = Bitcoin


### PR DESCRIPTION
Replace all require calls in tests with imports for consistency. Also replaced a few buffer usages with the built-in buffer as discovered.

**Test Plan**: lint, flow, test